### PR TITLE
Make loop for `smallest_dimension_yet` inclusive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,7 +380,7 @@ impl Grid {
         // Instead of numbers of columns, try to find the fewest number of *lines*
         // that the output will fit in.
         let mut smallest_dimensions_yet = None;
-        for num_lines in (1 .. theoretical_max_num_lines).rev() {
+        for num_lines in (1..=theoretical_max_num_lines).rev() {
 
             // The number of columns is the number of cells divided by the number
             // of lines, *rounded up*.


### PR DESCRIPTION
Closes https://github.com/ogham/rust-term-grid/issues/11

Hi! Thanks for this great library! Like I mentioned in the issue, we would love to upgrade to a later version, but this is blocking us, so I thought I would implement it in a PR. It contains exactly the change in the issue.