### PR TITLE
Fixed the bugs in displaying the grid with `fit_into_width`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,21 +397,31 @@ impl Grid {
             // also serves as a speed-up.
             let total_separator_width = (num_columns - 1) * self.options.filling.width();
             if maximum_width < total_separator_width {
-                continue;
+                return None;
             }
 
             // Remove the separator width from the available space.
-            let adjusted_width = maximum_width - total_separator_width;
+            let mut adjusted_width = maximum_width - total_separator_width;
+            let mut potential_dimensions = self.column_widths(num_lines, num_columns);
 
-            let potential_dimensions = self.column_widths(num_lines, num_columns);
-            if potential_dimensions.widths.iter().sum::<Width>() < adjusted_width {
+            while potential_dimensions.widths.iter().sum::<Width>() < adjusted_width {
                 smallest_dimensions_yet = Some(potential_dimensions);
-            } else {
-                return smallest_dimensions_yet;
+
+                if self.cell_count % num_lines != 0 {
+                    num_columns += 1;
+                    let total_separator_width = (num_columns - 1) * self.options.filling.width();
+                    if maximum_width < total_separator_width {
+                        break;
+                    }
+                    adjusted_width = maximum_width - total_separator_width;
+                    potential_dimensions = self.column_widths(num_lines, num_columns);
+                } else {
+                    break
+                }
             }
         }
 
-        None
+        smallest_dimensions_yet
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,7 +380,7 @@ impl Grid {
         // Instead of numbers of columns, try to find the fewest number of *lines*
         // that the output will fit in.
         let mut smallest_dimensions_yet = None;
-        for num_lines in (1 .. theoretical_max_num_lines).rev() {
+        for num_lines in (1 ..= theoretical_max_num_lines).rev() {
 
             // The number of columns is the number of cells divided by the number
             // of lines, *rounded up*.


### PR DESCRIPTION
These changes were initiated to fix the behavior of term-grid in [uutils](https://github.com/uutils/coreutils)'s `ls`, which uses term-grid 0.1.7 but can't upgrade to 0.2.0 due to the existence of these bugs.

Ideally, I'd like to upgrade to 0.2.0, offloading a lot of padding/alignment code to term-grid instead.

Things I've taken care of:
* Fixed loop boundaries.
* Allowed grid to try to utilize the maximum width it can, optimizing for line-count.

Things I've *not* taken care of, yet:
* I didn't create a test to make sure this behavior does not regress.
* I didn't fix the [other bug](https://github.com/ogham/rust-term-grid/issues/13) where terminal color-codes ruin the width calculation.