### PR TITLE
For avoiding divinding by 0(without stoping the execution)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,7 +296,10 @@ impl Grid {
     pub fn fit_into_columns(&self, num_columns: usize) -> Display<'_> {
         Display {
             grid:       self,
-            dimensions: self.columns_dimensions(num_columns),
+            dimensions: match num_columns {
+                0 => self.columns_dimensions(1), //To force the execution to continue.
+                _ => self.columns_dimensions(num_columns)
+            }
         }
     }
 


### PR DESCRIPTION
Before this update, **if the number of columns was 0, a division would still occur**, generating an unhandled error that prevented the program's visualization and execution. To solve this problem, I added a treatment that sets the number of columns to 1 if it is defined as 0. This will prevent the division by 0 and, consequently, the unhandled error. It is worth noting that it is still possible to apply an error treatment by notifying the user that there is not enough space in the terminal to define the number of columns. However, I believe that setting it to one is the ideal solution in most cases, such as in the command I was developing (to list directories). This update is a simple and effective solution to avoid unhandled errors in the Termgrid library of Rust. I hope this update can help improve the user experience with the Termgrid library of Rust and make its use easier and safer. I made this pull request in hope of this being relevant and good for the others.